### PR TITLE
fix: Pop!_OS uses COSMIC and has ARM version

### DIFF
--- a/data/distros.json
+++ b/data/distros.json
@@ -730,7 +730,7 @@
     "difficulty": "Beginner",
     "yearReleased": 2017,
     "desktopEnvironment": "COSMIC",
-    "architecture": "x86_64",
+    "architecture": "x86_64, ARM",
     "category": "Desktop",
     "popularity": "High",
     "discontinued": "No"

--- a/data/distros.json
+++ b/data/distros.json
@@ -729,7 +729,7 @@
     "packageManager": "APT",
     "difficulty": "Beginner",
     "yearReleased": 2017,
-    "desktopEnvironment": "GNOME",
+    "desktopEnvironment": "COSMIC",
     "architecture": "x86_64",
     "category": "Desktop",
     "popularity": "High",


### PR DESCRIPTION
The latest release, 24.04, only comes with COSMIC.

It's available for amd64 and arm64:
https://system76.com/pop/download/