### PR TITLE
Add Learn Mode feature with interactive distro family tree

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,7 @@
                         Discontinued
                     </label>
                     <button id="how-to-play-btn" class="btn option-help-btn">How To Play</button>
+                    <button id="learn-mode-btn" class="btn option-help-btn">Learn</button>
                 </div>
             </div>
             <div class="legend">
@@ -113,6 +114,76 @@
                     <li>Pool options let you include Very Low popularity and discontinued distros.</li>
                 </ul>
                 <button id="close-instructions-btn" class="btn">Close</button>
+            </div>
+        </div>
+
+        <div id="learn-mode-modal" class="hidden">
+            <div class="modal-content learn-mode-content">
+                <div class="learn-mode-header">
+                    <h2>Linux Distribution Family Tree</h2>
+                    <button id="close-learn-mode-btn" class="btn btn-close">×</button>
+                </div>
+
+                <div class="learn-mode-filters">
+                    <input type="text" id="learn-search" placeholder="Search distros..." autocomplete="off">
+
+                    <select id="learn-category-filter">
+                        <option value="all">All Categories</option>
+                        <option value="Desktop">Desktop</option>
+                        <option value="Server">Server</option>
+                        <option value="Gaming">Gaming</option>
+                        <option value="Security">Security</option>
+                        <option value="Enterprise">Enterprise</option>
+                    </select>
+
+                    <label class="learn-filter-checkbox">
+                        <input type="checkbox" id="learn-paid-only">
+                        Paid Only
+                    </label>
+
+                    <label class="learn-filter-checkbox">
+                        <input type="checkbox" id="learn-active-only" checked>
+                        Active Only
+                    </label>
+
+                    <div class="learn-expand-controls">
+                        <button id="learn-expand-all" class="btn btn-small">Expand All</button>
+                        <button id="learn-collapse-all" class="btn btn-small">Collapse All</button>
+                    </div>
+                </div>
+
+                <div id="learn-tree-container" class="learn-tree-container"></div>
+
+                <div class="learn-legend">
+                    <div class="legend-section">
+                        <h3>Symbols</h3>
+                        <div class="legend-grid">
+                            <div><span class="symbol">◆</span> Independent</div>
+                            <div><span class="symbol">$</span> Paid</div>
+                            <div><span class="symbol">★</span> Gaming</div>
+                            <div><span class="symbol">⚠</span> Discontinued</div>
+                        </div>
+                    </div>
+                    <div class="legend-section">
+                        <h3>Category Colors</h3>
+                        <div class="legend-grid">
+                            <div><span class="legend-box cat-desktop"></span> Desktop</div>
+                            <div><span class="legend-box cat-server"></span> Server</div>
+                            <div><span class="legend-box cat-gaming"></span> Gaming</div>
+                            <div><span class="legend-box cat-security"></span> Security</div>
+                            <div><span class="legend-box cat-enterprise"></span> Enterprise</div>
+                        </div>
+                    </div>
+                    <div class="legend-section">
+                        <h3>Difficulty Borders</h3>
+                        <div class="legend-grid">
+                            <div><span class="legend-box diff-beginner"></span> Beginner</div>
+                            <div><span class="legend-box diff-intermediate"></span> Intermediate</div>
+                            <div><span class="legend-box diff-advanced"></span> Advanced</div>
+                            <div><span class="legend-box diff-expert"></span> Expert</div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -703,6 +703,501 @@ function toggleInstructionsModal() {
     }
 }
 
+// Learn Mode state and functions
+let learnModeTree = null;
+let learnModeDistros = null;
+let learnModeFilters = {
+    search: '',
+    category: 'all',
+    paidOnly: false,
+    activeOnly: true
+};
+let searchDebounceTimer = null;
+
+const learnModeModal = document.getElementById('learn-mode-modal');
+const learnModeBtn = document.getElementById('learn-mode-btn');
+const closeLearnModeBtn = document.getElementById('close-learn-mode-btn');
+const learnTreeContainer = document.getElementById('learn-tree-container');
+const learnSearchInput = document.getElementById('learn-search');
+const learnCategoryFilter = document.getElementById('learn-category-filter');
+const learnPaidOnlyCheckbox = document.getElementById('learn-paid-only');
+const learnActiveOnlyCheckbox = document.getElementById('learn-active-only');
+const learnExpandAllBtn = document.getElementById('learn-expand-all');
+const learnCollapseAllBtn = document.getElementById('learn-collapse-all');
+
+function buildDistroTree(distros) {
+    // Create a map of all distros
+    const distroMap = new Map();
+
+    distros.forEach(distro => {
+        distroMap.set(distro.name, {
+            ...distro,
+            children: [],
+            isExpanded: true
+        });
+    });
+
+    // Handle special case: Mageia references "Mandriva" but the name is "Mandriva Linux"
+    distros.forEach(distro => {
+        const node = distroMap.get(distro.name);
+        let parentName = distro.parentDistro;
+
+        // Special case for Mageia
+        if (parentName === 'Mandriva' && !distroMap.has('Mandriva')) {
+            parentName = 'Mandriva Linux';
+        }
+
+        if (parentName !== 'Independent' && distroMap.has(parentName)) {
+            const parent = distroMap.get(parentName);
+            parent.children.push(node);
+        }
+    });
+
+    // Get root nodes (independent distros) and sort by year
+    const roots = Array.from(distroMap.values())
+        .filter(d => d.parentDistro === 'Independent')
+        .sort((a, b) => a.yearReleased - b.yearReleased);
+
+    // Sort children alphabetically for each node
+    function sortChildren(node) {
+        if (node.children.length > 0) {
+            node.children.sort((a, b) => a.name.localeCompare(b.name));
+            node.children.forEach(sortChildren);
+        }
+    }
+
+    roots.forEach(sortChildren);
+
+    return roots;
+}
+
+function getCategoryClass(category) {
+    const categories = category.toLowerCase();
+    if (categories.includes('gaming')) return 'cat-gaming';
+    if (categories.includes('security') || categories.includes('penetration')) return 'cat-security';
+    if (categories.includes('enterprise')) return 'cat-enterprise';
+    if (categories.includes('server')) return 'cat-server';
+    if (categories.includes('desktop')) return 'cat-desktop';
+    return '';
+}
+
+function getDifficultyClass(difficulty) {
+    const diff = difficulty.toLowerCase();
+    if (diff === 'beginner') return 'diff-beginner';
+    if (diff === 'intermediate') return 'diff-intermediate';
+    if (diff === 'advanced') return 'diff-advanced';
+    if (diff === 'expert') return 'diff-expert';
+    return '';
+}
+
+function getNodeSymbols(node) {
+    let symbols = [];
+
+    if (node.parentDistro === 'Independent') {
+        symbols.push('◆');
+    }
+    if (node.paid) {
+        symbols.push('$');
+    }
+    if (node.category && node.category.toLowerCase().includes('gaming')) {
+        symbols.push('★');
+    }
+    if (node.discontinued === 'Yes') {
+        symbols.push('⚠');
+    }
+
+    return symbols.join(' ');
+}
+
+function matchesFilters(node) {
+    // Search filter
+    if (learnModeFilters.search) {
+        const searchLower = learnModeFilters.search.toLowerCase();
+        if (!node.name.toLowerCase().includes(searchLower)) {
+            return false;
+        }
+    }
+
+    // Category filter
+    if (learnModeFilters.category !== 'all') {
+        if (!node.category.toLowerCase().includes(learnModeFilters.category.toLowerCase())) {
+            return false;
+        }
+    }
+
+    // Paid filter
+    if (learnModeFilters.paidOnly && !node.paid) {
+        return false;
+    }
+
+    // Active filter
+    if (learnModeFilters.activeOnly && node.discontinued === 'Yes') {
+        return false;
+    }
+
+    return true;
+}
+
+function hasMatchingDescendants(node) {
+    if (matchesFilters(node)) {
+        return true;
+    }
+
+    return node.children.some(hasMatchingDescendants);
+}
+
+function renderTreeNode(node, level = 0, isLastChild = true, prefix = '') {
+    // Check if this node or any descendants match filters
+    if (!hasMatchingDescendants(node)) {
+        return '';
+    }
+
+    const nodeMatches = matchesFilters(node);
+    const categoryClass = getCategoryClass(node.category);
+    const difficultyClass = getDifficultyClass(node.difficulty);
+    const symbols = getNodeSymbols(node);
+    const hasChildren = node.children.length > 0;
+    const expandIcon = hasChildren ? (node.isExpanded ? '▼' : '▶') : '';
+    const expandIconClass = hasChildren ? '' : 'no-children';
+
+    // Build tree line prefix
+    const lineChar = isLastChild ? '└─' : '├─';
+    const fullPrefix = level > 0 ? prefix + lineChar + ' ' : '';
+
+    // Store distro data for tooltip
+    const distroData = JSON.stringify({
+        name: node.name,
+        yearReleased: node.yearReleased,
+        parentDistro: node.parentDistro,
+        category: node.category,
+        difficulty: node.difficulty,
+        paid: node.paid,
+        discontinued: node.discontinued,
+        initSystem: node.initSystem,
+        packageManager: node.packageManager,
+        desktopEnvironment: node.desktopEnvironment,
+        popularity: node.popularity,
+        architecture: node.architecture,
+        releaseType: node.releaseType
+    }).replace(/"/g, '&quot;');
+
+    let html = '';
+
+    if (nodeMatches) {
+        html += `<div class="tree-node ${categoryClass} ${difficultyClass}" data-node-id="${node.id}">`;
+        html += `  <div class="tree-node-content">`;
+        html += `    <span class="tree-line-prefix">${fullPrefix}</span>`;
+        html += `    <span class="tree-expand-icon ${expandIconClass}">${expandIcon}</span>`;
+        html += `    <span class="tree-node-name" data-distro='${distroData}'>${node.name}</span>`;
+        if (symbols) {
+            html += `    <span class="tree-node-symbols">${symbols}</span>`;
+        }
+        html += `  </div>`;
+
+        if (hasChildren) {
+            const childPrefix = level > 0 ? prefix + (isLastChild ? '  ' : '│ ') : '';
+            const childrenClass = node.isExpanded ? '' : 'collapsed';
+            html += `  <div class="tree-children ${childrenClass}">`;
+            node.children.forEach((child, index) => {
+                const isLast = index === node.children.length - 1;
+                html += renderTreeNode(child, level + 1, isLast, childPrefix);
+            });
+            html += `  </div>`;
+        }
+
+        html += `</div>`;
+    } else if (hasChildren) {
+        // Node doesn't match but has children that might match
+        const childPrefix = level > 0 ? prefix + (isLastChild ? '  ' : '│ ') : '';
+        node.children.forEach((child, index) => {
+            const isLast = index === node.children.length - 1;
+            html += renderTreeNode(child, level, isLast, prefix);
+        });
+    }
+
+    return html;
+}
+
+function renderLearnModeTree() {
+    if (!learnModeTree || !learnTreeContainer) return;
+
+    let html = '';
+    learnModeTree.forEach(root => {
+        html += renderTreeNode(root, 0, true, '');
+    });
+
+    if (html === '') {
+        html = '<div style="padding: 2rem; text-align: center; color: var(--text-secondary);">No distros match the current filters.</div>';
+    }
+
+    learnTreeContainer.innerHTML = html;
+
+    // Add click handlers for expand/collapse
+    learnTreeContainer.querySelectorAll('.tree-node').forEach(nodeEl => {
+        const nodeId = nodeEl.dataset.nodeId;
+        const expandIcon = nodeEl.querySelector('.tree-expand-icon');
+
+        if (expandIcon && !expandIcon.classList.contains('no-children')) {
+            expandIcon.addEventListener('click', (e) => {
+                e.stopPropagation();
+                toggleNodeExpansion(nodeId);
+            });
+        }
+    });
+
+    // Add tooltip handlers for distro names
+    setupDistroTooltips();
+}
+
+let tooltipElement = null;
+
+function setupDistroTooltips() {
+    const distroNames = learnTreeContainer.querySelectorAll('.tree-node-name');
+
+    distroNames.forEach(nameEl => {
+        nameEl.addEventListener('mouseenter', showDistroTooltip);
+        nameEl.addEventListener('mousemove', moveDistroTooltip);
+        nameEl.addEventListener('mouseleave', hideDistroTooltip);
+    });
+}
+
+function showDistroTooltip(e) {
+    const distroData = JSON.parse(e.target.dataset.distro);
+
+    // Create tooltip element
+    tooltipElement = document.createElement('div');
+    tooltipElement.className = 'distro-tooltip';
+
+    const paidStatus = distroData.paid ? 'Yes' : 'No';
+    const discontinuedStatus = distroData.discontinued;
+
+    tooltipElement.innerHTML = `
+        <div class="distro-tooltip-header">${distroData.name}</div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Year Released:</span>
+            <span class="distro-tooltip-value">${distroData.yearReleased}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Parent:</span>
+            <span class="distro-tooltip-value">${distroData.parentDistro}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Category:</span>
+            <span class="distro-tooltip-value">${distroData.category}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Difficulty:</span>
+            <span class="distro-tooltip-value">${distroData.difficulty}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Package Manager:</span>
+            <span class="distro-tooltip-value">${distroData.packageManager}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Init System:</span>
+            <span class="distro-tooltip-value">${distroData.initSystem}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Desktop:</span>
+            <span class="distro-tooltip-value">${distroData.desktopEnvironment}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Release Type:</span>
+            <span class="distro-tooltip-value">${distroData.releaseType}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Architecture:</span>
+            <span class="distro-tooltip-value">${distroData.architecture}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Popularity:</span>
+            <span class="distro-tooltip-value">${distroData.popularity}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Paid:</span>
+            <span class="distro-tooltip-value">${paidStatus}</span>
+        </div>
+        <div class="distro-tooltip-row">
+            <span class="distro-tooltip-label">Status:</span>
+            <span class="distro-tooltip-value">${discontinuedStatus === 'Yes' ? 'Discontinued' : 'Active'}</span>
+        </div>
+    `;
+
+    document.body.appendChild(tooltipElement);
+    moveDistroTooltip(e);
+}
+
+function moveDistroTooltip(e) {
+    if (!tooltipElement) return;
+
+    const tooltipWidth = tooltipElement.offsetWidth;
+    const tooltipHeight = tooltipElement.offsetHeight;
+    const padding = 15;
+
+    let left = e.clientX + padding;
+    let top = e.clientY + padding;
+
+    // Adjust if tooltip goes off right edge
+    if (left + tooltipWidth > window.innerWidth) {
+        left = e.clientX - tooltipWidth - padding;
+    }
+
+    // Adjust if tooltip goes off bottom edge
+    if (top + tooltipHeight > window.innerHeight) {
+        top = e.clientY - tooltipHeight - padding;
+    }
+
+    tooltipElement.style.left = left + 'px';
+    tooltipElement.style.top = top + 'px';
+}
+
+function hideDistroTooltip() {
+    if (tooltipElement) {
+        tooltipElement.remove();
+        tooltipElement = null;
+    }
+}
+
+function toggleNodeExpansion(nodeId) {
+    // Find and toggle the node in the tree
+    function toggleInTree(nodes) {
+        for (const node of nodes) {
+            if (node.id === nodeId) {
+                node.isExpanded = !node.isExpanded;
+                return true;
+            }
+            if (node.children.length > 0 && toggleInTree(node.children)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    toggleInTree(learnModeTree);
+    renderLearnModeTree();
+}
+
+function expandAllNodes(nodes) {
+    nodes.forEach(node => {
+        node.isExpanded = true;
+        if (node.children.length > 0) {
+            expandAllNodes(node.children);
+        }
+    });
+}
+
+function collapseAllNodes(nodes) {
+    nodes.forEach(node => {
+        node.isExpanded = false;
+        if (node.children.length > 0) {
+            collapseAllNodes(node.children);
+        }
+    });
+}
+
+async function openLearnMode() {
+    if (!learnModeModal) return;
+
+    // Fetch distros if not already loaded
+    if (!learnModeDistros) {
+        try {
+            const response = await fetch('/api/distros/full?includeVeryLow=true&includeDiscontinued=true');
+            if (!response.ok) {
+                showToast('Failed to load distros for Learn Mode', 'error');
+                return;
+            }
+            learnModeDistros = await response.json();
+        } catch (error) {
+            console.error('Error loading distros:', error);
+            showToast('Failed to load distros for Learn Mode', 'error');
+            return;
+        }
+    }
+
+    // Build tree if not already built
+    if (!learnModeTree) {
+        learnModeTree = buildDistroTree(learnModeDistros);
+    }
+
+    // Render tree
+    renderLearnModeTree();
+
+    // Show modal
+    learnModeModal.classList.remove('hidden');
+}
+
+function closeLearnMode() {
+    if (!learnModeModal) return;
+    learnModeModal.classList.add('hidden');
+    hideDistroTooltip();
+}
+
+function applyLearnModeFilters() {
+    renderLearnModeTree();
+}
+
+// Event listeners for Learn Mode
+if (learnModeBtn) {
+    learnModeBtn.addEventListener('click', openLearnMode);
+}
+
+if (closeLearnModeBtn) {
+    closeLearnModeBtn.addEventListener('click', closeLearnMode);
+}
+
+if (learnModeModal) {
+    learnModeModal.addEventListener('click', (e) => {
+        if (e.target === learnModeModal) {
+            closeLearnMode();
+        }
+    });
+}
+
+if (learnSearchInput) {
+    learnSearchInput.addEventListener('input', (e) => {
+        clearTimeout(searchDebounceTimer);
+        searchDebounceTimer = setTimeout(() => {
+            learnModeFilters.search = e.target.value.trim();
+            applyLearnModeFilters();
+        }, 300);
+    });
+}
+
+if (learnCategoryFilter) {
+    learnCategoryFilter.addEventListener('change', (e) => {
+        learnModeFilters.category = e.target.value;
+        applyLearnModeFilters();
+    });
+}
+
+if (learnPaidOnlyCheckbox) {
+    learnPaidOnlyCheckbox.addEventListener('change', (e) => {
+        learnModeFilters.paidOnly = e.target.checked;
+        applyLearnModeFilters();
+    });
+}
+
+if (learnActiveOnlyCheckbox) {
+    learnActiveOnlyCheckbox.addEventListener('change', (e) => {
+        learnModeFilters.activeOnly = e.target.checked;
+        applyLearnModeFilters();
+    });
+}
+
+if (learnExpandAllBtn) {
+    learnExpandAllBtn.addEventListener('click', () => {
+        expandAllNodes(learnModeTree);
+        renderLearnModeTree();
+    });
+}
+
+if (learnCollapseAllBtn) {
+    learnCollapseAllBtn.addEventListener('click', () => {
+        collapseAllNodes(learnModeTree);
+        renderLearnModeTree();
+    });
+}
+
 // Confetti effect
 function createConfetti() {
     const colors = ['#4a9eff', '#4ade80', '#facc15'];
@@ -846,6 +1341,7 @@ document.addEventListener('keypress', (e) => {
 document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
         closeInstructionsModal();
+        closeLearnMode();
     }
 });
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -395,6 +395,20 @@ header p {
     }
 }
 
+.confetti {
+    position: fixed;
+    top: -10px;
+    z-index: 10001;
+    animation: confettiFall 2s ease-out forwards;
+}
+
+@keyframes confettiFall {
+    to {
+        transform: translateY(100vh) rotate(360deg);
+        opacity: 0;
+    }
+}
+
 .hidden {
     display: none !important;
 }
@@ -623,5 +637,380 @@ footer {
     
     footer {
         padding: 1rem;
+    }
+}
+
+/* Learn Mode Modal Styles */
+#learn-mode-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+}
+
+.learn-mode-content {
+    max-width: 1000px;
+    width: 100%;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem;
+}
+
+.learn-mode-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.learn-mode-header h2 {
+    margin: 0;
+    color: var(--accent);
+    font-size: 1.3rem;
+}
+
+.btn-close {
+    font-size: 1.5rem;
+    padding: 0.25rem 0.75rem;
+    line-height: 1;
+    min-width: auto;
+}
+
+.learn-mode-filters {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+#learn-search {
+    flex: 1;
+    min-width: 200px;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg-dark);
+    border: 2px solid var(--border-color);
+    border-radius: 2px;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+#learn-search:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+#learn-category-filter {
+    padding: 0.5rem 0.75rem;
+    background: var(--bg-dark);
+    border: 2px solid var(--border-color);
+    border-radius: 2px;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+#learn-category-filter:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.learn-filter-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    border-radius: 2px;
+}
+
+.learn-filter-checkbox input[type="checkbox"] {
+    accent-color: var(--accent);
+}
+
+.learn-expand-controls {
+    display: flex;
+    gap: 0.35rem;
+    margin-left: auto;
+}
+
+.btn-small {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.75rem;
+}
+
+.learn-tree-container {
+    flex: 1;
+    overflow-y: auto;
+    background: var(--bg-dark);
+    border: 2px solid var(--border-color);
+    border-radius: 2px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.tree-node {
+    margin: 0.25rem 0;
+    padding: 0.5rem 0.75rem;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: all 0.2s;
+    border: 2px solid transparent;
+}
+
+.tree-node:hover {
+    background: rgba(74, 158, 255, 0.1);
+}
+
+.tree-node-content {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.tree-expand-icon {
+    display: inline-block;
+    width: 16px;
+    text-align: center;
+    color: var(--accent);
+    font-weight: bold;
+    user-select: none;
+}
+
+.tree-expand-icon.no-children {
+    opacity: 0;
+}
+
+.tree-line-prefix {
+    color: var(--text-secondary);
+    white-space: pre;
+    font-family: monospace;
+}
+
+.tree-node-name {
+    font-weight: bold;
+    color: var(--text-primary);
+    position: relative;
+    cursor: help;
+}
+
+.tree-node-name:hover {
+    color: var(--accent);
+}
+
+.distro-tooltip {
+    position: fixed;
+    background: var(--bg-panel);
+    border: 2px solid var(--accent);
+    border-radius: 4px;
+    padding: 0.75rem;
+    z-index: 10000;
+    pointer-events: none;
+    min-width: 250px;
+    max-width: 350px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    animation: tooltipFadeIn 0.15s ease-out;
+}
+
+.distro-tooltip-header {
+    font-weight: bold;
+    color: var(--accent);
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.distro-tooltip-row {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 0.5rem;
+    margin: 0.35rem 0;
+    font-size: 0.8rem;
+}
+
+.distro-tooltip-label {
+    color: var(--text-secondary);
+    font-weight: normal;
+}
+
+.distro-tooltip-value {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+@keyframes tooltipFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.tree-node-symbols {
+    color: var(--partial);
+    font-size: 0.85rem;
+}
+
+.tree-children {
+    margin-left: 20px;
+}
+
+.tree-children.collapsed {
+    display: none;
+}
+
+/* Category background colors */
+.cat-desktop {
+    background: rgba(74, 158, 255, 0.15);
+}
+
+.cat-server {
+    background: rgba(139, 92, 246, 0.15);
+}
+
+.cat-gaming {
+    background: rgba(250, 204, 21, 0.15);
+}
+
+.cat-security {
+    background: rgba(239, 68, 68, 0.15);
+}
+
+.cat-enterprise {
+    background: rgba(16, 185, 129, 0.15);
+}
+
+/* Difficulty border colors */
+.diff-beginner {
+    border-color: #4ade80 !important;
+}
+
+.diff-intermediate {
+    border-color: #facc15 !important;
+}
+
+.diff-advanced {
+    border-color: #fb923c !important;
+}
+
+.diff-expert {
+    border-color: #ef4444 !important;
+}
+
+.learn-legend {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    padding: 1rem;
+    background: var(--bg-dark);
+    border: 2px solid var(--border-color);
+    border-radius: 2px;
+}
+
+.legend-section h3 {
+    font-size: 0.75rem;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.5rem;
+}
+
+.legend-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+}
+
+.legend-grid div {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.legend-box {
+    width: 20px;
+    height: 16px;
+    border: 2px solid;
+    border-radius: 2px;
+    display: inline-block;
+}
+
+.symbol {
+    font-weight: bold;
+    color: var(--partial);
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+    #learn-mode-modal {
+        padding: 0;
+    }
+
+    .learn-mode-content {
+        max-width: 100%;
+        max-height: 100vh;
+        border-radius: 0;
+        padding: 1rem;
+    }
+
+    .learn-mode-header h2 {
+        font-size: 1.1rem;
+    }
+
+    .learn-mode-filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    #learn-search,
+    #learn-category-filter {
+        width: 100%;
+    }
+
+    .learn-expand-controls {
+        width: 100%;
+        margin-left: 0;
+    }
+
+    .learn-expand-controls button {
+        flex: 1;
+    }
+
+    .tree-line-prefix {
+        display: none;
+    }
+
+    .tree-children {
+        margin-left: 15px;
+    }
+
+    .learn-legend {
+        grid-template-columns: 1fr;
+        gap: 0.75rem;
+    }
+
+    .tree-node {
+        padding: 0.75rem;
+    }
+
+    .tree-node-content {
+        font-size: 0.85rem;
     }
 }

--- a/server.js
+++ b/server.js
@@ -88,6 +88,15 @@ app.get('/api/distros', (req, res) => {
     res.json(filteredDistros.map(d => d.name));
 });
 
+// Get full distro data for Learn Mode
+app.get('/api/distros/full', (req, res) => {
+    const includeVeryLow = parseBooleanOption(req.query.includeVeryLow, true);
+    const includeDiscontinued = parseBooleanOption(req.query.includeDiscontinued, true);
+    const filteredDistros = getFilteredDistros({ includeVeryLow, includeDiscontinued });
+
+    res.json(filteredDistros);
+});
+
 // Get random target distro
 app.get('/api/target', (req, res) => {
     const gameState = getGameState(req);


### PR DESCRIPTION
Implement comprehensive Learn Mode that displays a hierarchical tree of all 71 Linux distributions showing relationships from independent distros to their derivatives.

Features:
- Interactive family tree with expand/collapse functionality
- Color-coded categories (Desktop, Server, Gaming, Security, Enterprise)
- Difficulty-level border colors (Beginner, Intermediate, Advanced, Expert)
- Symbol indicators (◆ Independent, $ Paid, ★ Gaming, ⚠ Discontinued)
- Real-time search with 300ms debounce
- Filters: category dropdown, paid only, active/discontinued toggle
- Expand All / Collapse All buttons
- Hover tooltips showing full distro information (year, parent, category, difficulty, package manager, init system, desktop environment, release type, architecture, popularity, status)
- Mobile responsive design (hides tree characters, uses indentation)
- Escape key and click-outside-to-close support

Technical:
- Add /api/distros/full endpoint to return complete distro objects
- Tree building algorithm with parent-child linking (22 independent roots, 49 derivatives)
- Recursive tree rendering with Unicode characters (├─ └─ │)
- Smart tooltip positioning to avoid screen edges
- Special handling for Mageia parent reference (Mandriva → Mandriva Linux)