### PR TITLE
Fix casing for obsidianos package manager

### DIFF
--- a/data/distros.json
+++ b/data/distros.json
@@ -806,7 +806,7 @@
     "initSystem": "systemd",
     "releaseType": "Rolling",
     "parentDistro": "Independent",
-    "packageManager": "pacman",
+    "packageManager": "Pacman",
     "difficulty": "Advanced",
     "yearReleased": 2025,
     "desktopEnvironment": "KDE, COSMIC",


### PR DESCRIPTION
Having it set as `pacman` instead of `Pacman` meant it did not match green with other `Pacman` using distros